### PR TITLE
Interface generation bug for Array of objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/model.mustache
@@ -33,7 +33,7 @@ export interface I{{#lambda.pascalcase}}{{classname}}{{/lambda.pascalcase}} {
   {{#fnDelIdentifier}}{{name}}?: {{#isModel}}I{{#lambda.pascalcase}}{{datatype}}{{/lambda.pascalcase}}{{/isModel}}{{^isModel}}{{#isNumeric}}number{{/isNumeric}}{{#isDate}}Date{{/isDate}}{{#isString}}string{{/isString}}{{#isBoolean}}boolean{{/isBoolean}}{{#isFreeFormObject}}object{{/isFreeFormObject}}{{#isEnumRef}}{{^isString}}string{{/isString}}{{/isEnumRef}}{{/isModel}},{{/fnDelIdentifier}}
 {{/isArray}}
 {{#isArray}}
-  {{name}}?: {{#mostInnerItems}}{{#isModel}}I{{#lambda.pascalcase}}{{datatype}}{{/lambda.pascalcase}}[]{{/isModel}}{{^isModel}}{{#isEnumRef}}string{{/isEnumRef}}{{^isEnumRef}}{{#lambda.camelcase}}{{datatype}}{{/lambda.camelcase}}{{/isEnumRef}}{{/isModel}}[]{{/mostInnerItems}},
+  {{name}}?: {{#mostInnerItems}}{{#isModel}}I{{#lambda.pascalcase}}{{datatype}}{{/lambda.pascalcase}}{{/isModel}}{{^isModel}}{{#isEnumRef}}string{{/isEnumRef}}{{^isEnumRef}}{{#lambda.camelcase}}{{datatype}}{{/lambda.camelcase}}{{/isEnumRef}}{{/isModel}}[]{{/mostInnerItems}},
 {{/isArray}}
 {{/vendorExtensions.x-mongo-model-ref}}
 {{/vars}}


### PR DESCRIPTION
When an array of objects is defined, the interface generated was incorrect.

It added [][] instead of [] to the output.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
