### PR TITLE
Minor Improvements:

### DIFF
--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/api-error.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/api-error.mustache
@@ -50,7 +50,10 @@ export default class APIError extends Error {
 
 //If the input err is an APIError then it returns the object unaltered.
 //Else it wraps the 'Error' object usign the message and status code provieded as APIError.
-export function WrapError(message: string, statusCode: number, err: Error | APIError) {
+export function WrapError(err: Error | APIError, message?: string, statusCode?: number) {
+    message = message ?? 'Internal server error';
+    statusCode = statusCode ?? httpStatus.INTERNAL_SERVER_ERROR;
+
     let apiErr: APIError;
     if (err instanceof APIError) {
         apiErr = err;
@@ -60,3 +63,4 @@ export function WrapError(message: string, statusCode: number, err: Error | APIE
 
     return apiErr;
 }
+

--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/controllers/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/controllers/Controller.mustache
@@ -25,11 +25,7 @@ export default class Controller {
     }
 
    static sendError(response: any, error: APIError | Error) {
-        let apiErr: APIError = WrapError(
-            'Internal Server Error',
-            httpStatus.INTERNAL_SERVER_ERROR,
-            error
-        );
+        let apiErr: APIError = WrapError(error);
         logger.error(apiErr);
         response.status(apiErr.statusCode);
         response.json(apiErr);

--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/model.mustache
@@ -48,6 +48,7 @@ export const {{#lambda.camelcase}}{{classname}}Schema{{/lambda.camelcase}} = new
       type: mongoose.Schema.Types.ObjectId,
       ref: '{{vendorExtensions.x-mongo-model-ref}}',
       {{#vendorExtensions.x-mongo-required}}required: true,{{/vendorExtensions.x-mongo-required}}
+      {{#vendorExtensions.x-mongo-unique}}unique: true,{{/vendorExtensions.x-mongo-unique}}
     },
     {{/isArray}}
     {{#isArray}}
@@ -56,7 +57,7 @@ export const {{#lambda.camelcase}}{{classname}}Schema{{/lambda.camelcase}} = new
     {{/vendorExtensions.x-mongo-model-ref}}
     {{^vendorExtensions.x-mongo-model-ref}}
     {{^isArray}}
-      {{#fnDelIdentifier}}{{name}}: { type: {{#isModel}}{{#lambda.camelcase}}{{datatype}}Schema{{/lambda.camelcase}}{{/isModel}}{{^isModel}}{{#isNumeric}}Number{{/isNumeric}}{{#isDate}}Date{{/isDate}}{{#isUuid}}Schema.Types.ObjectId{{/isUuid}}{{^isUuid}}{{#isString}}String{{/isString}}{{/isUuid}}{{#isBoolean}}Boolean{{/isBoolean}}{{#isFreeFormObject}}Object{{/isFreeFormObject}}{{#isEnumRef}}{{^isString}}String{{/isString}}{{/isEnumRef}}{{/isModel}}, {{#isString}}trim: true,{{/isString}} {{#vendorExtensions.x-mongo-required}}required: true,{{/vendorExtensions.x-mongo-required}} {{#minimum}}min: {{minimum}},{{/minimum}} {{#maximum}}max: {{maximum}},{{/maximum}} {{#isEnumRef}}enum: [{{#allowableValues}}{{#values}}{{#isEnum}}{{classname}}{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}.{{#lambda.uppercase}}{{.}}{{/lambda.uppercase}}{{^-last}},{{/-last}}{{/values}}{{/allowableValues}}],{{/isEnumRef}} },{{/fnDelIdentifier}} 
+      {{#fnDelIdentifier}}{{name}}: { type: {{#isModel}}{{#lambda.camelcase}}{{datatype}}Schema{{/lambda.camelcase}}{{/isModel}}{{^isModel}}{{#isNumeric}}Number{{/isNumeric}}{{#isDate}}Date{{/isDate}}{{#isUuid}}Schema.Types.ObjectId{{/isUuid}}{{^isUuid}}{{#isString}}String{{/isString}}{{/isUuid}}{{#isBoolean}}Boolean{{/isBoolean}}{{#isFreeFormObject}}Object{{/isFreeFormObject}}{{#isEnumRef}}{{^isString}}String{{/isString}}{{/isEnumRef}}{{/isModel}}, {{#isString}}trim: true,{{/isString}} {{#vendorExtensions.x-mongo-required}}required: true,{{/vendorExtensions.x-mongo-required}} {{#vendorExtensions.x-mongo-unique}}unique: true,{{/vendorExtensions.x-mongo-unique}} {{#minimum}}min: {{minimum}},{{/minimum}} {{#maximum}}max: {{maximum}},{{/maximum}} {{#isEnumRef}}enum: [{{#allowableValues}}{{#values}}{{#isEnum}}{{classname}}{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}.{{#lambda.uppercase}}{{.}}{{/lambda.uppercase}}{{^-last}},{{/-last}}{{/values}}{{/allowableValues}}],{{/isEnumRef}} },{{/fnDelIdentifier}} 
     {{/isArray}}
     {{#isArray}}
       {{name}}: [{{#mostInnerItems}}{{#isModel}}{{#lambda.camelcase}}{{datatype}}Schema{{/lambda.camelcase}}{{/isModel}}{{^isModel}}{{#isUuid}}Schema.Types.ObjectId{{/isUuid}}{{^isUuid}}{{#isEnumRef}} {type: String, enum: [ {{#allowableValues}}{{#values}}{{#isEnum}}{{classname}}{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}.{{#lambda.uppercase}}{{.}}{{/lambda.uppercase}}{{^-last}},{{/-last}}{{/values}}{{/allowableValues}} ] } {{/isEnumRef}}{{^isEnumRef}}{{dataType}}{{/isEnumRef}}{{/isUuid}}{{/isModel}}{{/mostInnerItems}}],

--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/models/plugins/paginate.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/models/plugins/paginate.mustache
@@ -7,15 +7,18 @@ const paginate = (schema: any) => {
 
         if (options.sortBy) {
             sort = options.sortBy.split(',').join(' ');
+            sort = sort + ' ' + '_id';
         } else {
-            sort = 'createdAt';
+            sort = '_id';
         }
 
-        const limit =
-            options.limit && parseInt(options.limit, 10) > 0 ? parseInt(options.limit, 10) : 10;
+        const perPage =
+            options.perPage && parseInt(options.perPage, 10) > 0
+                ? parseInt(options.perPage, 10)
+                : 10;
         const page =
             options.page && parseInt(options.page, 10) > 0 ? parseInt(options.page, 10) : 1;
-        const skip = (page - 1) * limit;
+        const skip = (page - 1) * perPage;
 
         let filter: any = {};
         //First copy the user provided filters (API filters)
@@ -28,7 +31,7 @@ const paginate = (schema: any) => {
         }
 
         const countPromise = this.countDocuments(filter).exec();
-        let docPromise = this.find(filter).sort(sort).skip(skip).limit(limit);
+        let docPromise = this.find(filter).sort(sort).skip(skip).limit(perPage);
 
         if (options.populate) {
             options.populate.split(',').forEach((populateOption: any) => {
@@ -49,13 +52,16 @@ const paginate = (schema: any) => {
 
         return Promise.all([countPromise, docPromise]).then((values) => {
             const [totalResults, results] = values;
-            const totalPages = Math.ceil(totalResults / limit);
+            const totalPages = Math.ceil(totalResults / perPage);
+            const pagination = {
+                currentPage: page,
+                pageCount: totalPages,
+                perPage: perPage,
+                totalCount: totalResults
+            };
             const result = {
                 results,
-                page,
-                limit,
-                totalPages,
-                totalResults
+                pagination
             };
             return Promise.resolve(result);
         });

--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/server.mustache
@@ -93,13 +93,9 @@ export default class Server {
         // that was not already caught by the controller.
         //Error Handler
         this.app.use((err: Error, req: any, res: any, next: any) => {
-            let apiErr: APIError = WrapError(
-                'Internal Server Error',
-                httpStatus.INTERNAL_SERVER_ERROR,
-                err
-            );
+            let apiErr: APIError = WrapError(err);
             logger.error('Exception: ', apiErr);
-            res.status(apiErr.statusCode).send(apiErr.combinedMessage());
+            res.status(apiErr.statusCode).send({ message: apiErr.combinedMessage() });
         });
 
         /* End of Default error handlers */

--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/service.mustache
@@ -29,12 +29,7 @@ const {{{operationId}}} = ({{#allParams}}{{#-first}}{ {{/-first}}{{^isBodyParam}
     try {
       resolve(Service.successResponse({}, 200));
     } catch (err) {
-      let apiErr: APIError = WrapError(
-            'Internal server error',
-            httpStatus.INTERNAL_SERVER_ERROR,
-            <Error>err
-      );
-      reject(apiErr);
+      reject(WrapError(<Error>err));
     }
   });
 {{/operation}}


### PR DESCRIPTION
1. Error message and status code to WrapError are made default parameters ('internal server error').
2. Modify the generated code to invoke WrapError without passing error message and status code (it will pick up the default error 'internal server error').
3. Support addition of 'unique' property in models.
4. paginate plugin is modified to sort the records based on ID before returning them.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
